### PR TITLE
Custom serde implementation for `InputMap`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ serde = {version = "1.0", features = ["derive"]}
 [dev-dependencies]
 bevy = {version = "0.8", default-features = false, features = ["bevy_asset", "bevy_sprite", "bevy_text", "bevy_ui", "bevy_render", "bevy_core_pipeline", "x11"]}
 bevy_egui = "0.15.0"
+serde_test = "1.0"
 
 [lib]
 name = "leafwing_input_manager"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,10 +1,10 @@
 # Release Notes
 
-## Unreleased 
+## Unreleased
 
-### Usability 
+### Usability
 
-- Added custom implementation of the `Serialize` and `Deserialize` traits for `InputMap` to make the format more human readable
+- Added custom implementation of the `Serialize` and `Deserialize` traits for `InputMap` to make the format more human readable.
 
 ## Version 0.6
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased 
+
+### Usability 
+
+- Add custom implementation of the `Serialize` and `Deserialize` traits for `InputMap` to make the format more human readable
+
 ## Version 0.6
 
 ### Enhancements

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,7 @@
 
 ### Usability 
 
-- Add custom implementation of the `Serialize` and `Deserialize` traits for `InputMap` to make the format more human readable
+- Added custom implementation of the `Serialize` and `Deserialize` traits for `InputMap` to make the format more human readable
 
 ## Version 0.6
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -432,6 +432,27 @@ impl<A: Actionlike> From<HashMap<A, Vec<UserInput>>> for InputMap<A> {
     /// # Panics
     ///
     /// Panics if the any value in map contains more than 16 distinct inputs.
+    /// # Example
+    /// ```rust
+    /// use leafwing_input_manager::input_map::InputMap;
+    /// use leafwing_input_manager::user_input::UserInput;
+    /// use leafwing_input_manager::Actionlike;
+    /// use bevy::input::keyboard::KeyCode;
+    ///
+    /// use std::collections::HashMap;
+    ///
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
+    /// enum Action {
+    ///     Run,
+    ///     Jump,
+    /// }
+    /// let mut map: HashMap<Action, Vec<UserInput>> = HashMap::default();
+    /// map.insert(
+    ///     Action::Run,
+    ///     vec![KeyCode::LShift.into(), KeyCode::RShift.into()],
+    /// );
+    /// let input_map = InputMap::from(map);
+    /// ```
     fn from(map: HashMap<A, Vec<UserInput>>) -> Self {
         map.iter()
             .flat_map(|(action, inputs)| inputs.iter().map(|input| (action.clone(), input.clone())))

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -536,62 +536,6 @@ mod tests {
     }
 
     #[test]
-    fn serde() {
-        use bevy::prelude::KeyCode;
-
-        let input_map = InputMap::new([
-            (KeyCode::LShift, Action::Run),
-            (KeyCode::RShift, Action::Run),
-            (KeyCode::Space, Action::Jump),
-        ]);
-
-        println!("RON: {}", ron::to_string(&input_map).unwrap());
-
-        let expected = InputMap::new([(KeyCode::LShift, Action::Run)]);
-        let full_struct = "InputMap( map: { Run: [Single(Keyboard(LShift))] } )";
-        assert_eq!(expected, ron::from_str(full_struct).unwrap());
-        let struct_without_name = "( map: { Run: [Single(Keyboard(LShift))] } )";
-        assert_eq!(expected, ron::from_str(struct_without_name).unwrap());
-    }
-
-    #[test]
-    fn custom_serde() {
-        use bevy::prelude::KeyCode;
-        use serde_test::assert_tokens;
-        use serde_test::Token;
-
-        let input_map = InputMap::new([
-            (KeyCode::LShift, Action::Run),
-            (KeyCode::RShift, Action::Run),
-            (KeyCode::Space, Action::Jump),
-        ]);
-
-        assert_tokens(
-            &input_map,
-            &[
-                Token::Struct {
-                    name: "InputMap",
-                    len: 1,
-                },
-                Token::Str("map"),
-                Token::Map { len: Some(3) },
-                Token::UnitVariant {
-                    name: "Action",
-                    variant: "Hide",
-                },
-                Token::Seq { len: Some(0) },
-                Token::SeqEnd,
-                Token::UnitVariant {
-                    name: "Action",
-                    variant: "Run",
-                },
-                Token::Seq { len: Some(2) },
-                Token::StructEnd,
-            ],
-        )
-    }
-
-    #[test]
     fn insertion_idempotency() {
         use bevy::input::keyboard::KeyCode;
         use petitset::PetitSet;

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -475,7 +475,7 @@ where
 
 impl<'de, A> Deserialize<'de> for InputMap<A>
 where
-    A: Actionlike + Eq + Hash + Deserialize<'de>,
+    A: Actionlike + Deserialize<'de> + Eq + Hash,
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -11,9 +11,9 @@ use bevy::ecs::component::Component;
 use bevy::input::gamepad::Gamepad;
 
 use core::fmt::Debug;
-use std::collections::HashMap;
 use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 /// Maps from raw inputs to an input-method agnostic representation
@@ -428,15 +428,14 @@ impl<A: Actionlike> InputMap<A> {
 }
 
 impl<A: Actionlike> From<HashMap<A, Vec<UserInput>>> for InputMap<A> {
-
     /// Create `InputMap<A>` from `HashMap<A, Vec<UserInput>>`
     ///
     /// # Panics
     ///
     /// Panics if the any value in map contains more than 16 distinct inputs.
     fn from(map: HashMap<A, Vec<UserInput>>) -> Self {
-        let bindings = map.iter().flat_map(|(action, inputs)| { 
-            inputs.iter().map(|input| (input.clone(), action.clone())) 
+        let bindings = map.iter().flat_map(|(action, inputs)| {
+            inputs.iter().map(|input| (input.clone(), action.clone()))
         });
         InputMap::new(bindings)
     }
@@ -575,13 +574,19 @@ mod tests {
 
     #[test]
     fn from_test() {
-        use std::collections::HashMap;
         use bevy::prelude::KeyCode;
+        use std::collections::HashMap;
 
-        let mut map: HashMap<Action, Vec<UserInput>>  = HashMap::default();
-        map.insert(Action::Hide, vec![UserInput::chord(vec![KeyCode::R, KeyCode::E])]);
+        let mut map: HashMap<Action, Vec<UserInput>> = HashMap::default();
+        map.insert(
+            Action::Hide,
+            vec![UserInput::chord(vec![KeyCode::R, KeyCode::E])],
+        );
         map.insert(Action::Jump, vec![UserInput::from(KeyCode::Space)]);
-        map.insert(Action::Run, vec![KeyCode::LShift.into(), KeyCode::RShift.into()]);
+        map.insert(
+            Action::Run,
+            vec![KeyCode::LShift.into(), KeyCode::RShift.into()],
+        );
 
         let mut input_map = InputMap::default();
         input_map.insert_chord(vec![KeyCode::R, KeyCode::E], Action::Hide);


### PR DESCRIPTION
Attemp to add custom serialization for `InputMap`
```Rust
InputMap(
    map: {
        Run:  [Single(Keyboard(LShift)),Single(Keyboard(RShift))],
        Jump: [Single(Keyboard(Space))],
        Hide: [Chord([Some(Keyboard(R)),Some(Keyboard(E)),None,None,None,None,None,None])]
    }
)
```

To achieve this format, I added four new traits::
- `impl<A: Actionlike> FromIterator<(A, UserInput)> for InputMap<A>`
- `impl<A: Actionlike> From<HashMap<A, Vec<UserInput>>> for InputMap<A>`
- `impl<A> Serialize for InputMap<A> where A: Actionlike + Serialize + Eq + Hash + Ord`
  - `Eq + Hash` since I'm using map to serialize inputs
  - `Ord` is for `BiTreeMap` so all actions will always serialize in the same order (I mainly need this to test serialization)
- `impl<'de, A> Deserialize<'de> for InputMap<A> where A: Actionlike + Deserialize<'de> + Eq + Hash`
  - `Eq + Hash` to be able deserialize `HashMap` 

Add new crate [serde-test](https://docs.rs/serde_test/latest/serde_test/) in dev-dependencies to be able to test a custom implementation of serde

Fixes